### PR TITLE
feat: 연동 계좌 삭제 기능 구현 & 테스트 (#23, SCRUM-59)

### DIFF
--- a/ssok-account-service/src/main/java/kr/ssok/accountservice/SsokAccountServiceApplication.java
+++ b/ssok-account-service/src/main/java/kr/ssok/accountservice/SsokAccountServiceApplication.java
@@ -2,9 +2,7 @@ package kr.ssok.accountservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class SsokAccountServiceApplication {
 

--- a/ssok-account-service/src/main/java/kr/ssok/accountservice/controller/AccountController.java
+++ b/ssok-account-service/src/main/java/kr/ssok/accountservice/controller/AccountController.java
@@ -23,10 +23,6 @@ public class AccountController {
 
     /**
      * 계좌 생성 요청을 처리합니다.
-     * <p>
-     * 클라이언트로부터 계좌 생성 요청을 받아 신규 연동 계좌를 생성하고,
-     * 생성된 계좌 정보를 반환합니다.
-     * </p>
      *
      * @param userId Gateway에서 전달된 사용자 ID (요청 헤더 "X-User-Id")
      * @param createAccountRequestDto 클라이언트로부터 전달받은 계좌 생성 요청 데이터
@@ -71,6 +67,22 @@ public class AccountController {
 
         return ResponseEntity.ok().body(new BaseResponse<>(AccountResponseStatus.ACCOUNT_GET_SUCCESS, result));
 
+    }
+
+    /**
+     * 특정 계좌 ID에 해당하는 연동 계좌를 삭제합니다.
+     *
+     * @param userId Gateway에서 전달된 사용자 ID (요청 헤더 "X-User-Id")
+     * @param accountId 삭제할 계좌 ID (Path Variable)
+     * @return 삭제된 계좌 정보를 담은 {@link BaseResponse}
+     */
+    @DeleteMapping("/{accountId}")
+    public ResponseEntity<BaseResponse<AccountResponseDto>> deleteAccountById(
+            @RequestHeader("X-User-Id") String userId,
+            @PathVariable("accountId") Long accountId) {
+        AccountResponseDto result = this.accountService.deleteLinkedAccount(Long.parseLong(userId), accountId);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(AccountResponseStatus.ACCOUNT_DELETE_SUCCESS, result));
     }
 
 

--- a/ssok-account-service/src/main/java/kr/ssok/accountservice/entity/LinkedAccount.java
+++ b/ssok-account-service/src/main/java/kr/ssok/accountservice/entity/LinkedAccount.java
@@ -5,12 +5,8 @@ import kr.ssok.accountservice.dto.response.AccountBalanceResponseDto;
 import kr.ssok.accountservice.dto.response.AccountResponseDto;
 import kr.ssok.accountservice.entity.enums.AccountTypeCode;
 import kr.ssok.accountservice.entity.enums.BankCode;
+import kr.ssok.common.entity.TimeStamp;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 /**
  * 사용자가 연동한 계좌 정보를 저장하는 JPA 엔티티
@@ -23,12 +19,11 @@ import java.time.LocalDateTime;
  * <p>생성일자, 수정일자는 스프링 데이터 JPA의 Auditing 기능을 통해 자동 관리됩니다.</p>
  */
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class LinkedAccount {
+public class LinkedAccount extends TimeStamp {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "account_id")
@@ -40,14 +35,6 @@ public class LinkedAccount {
     @Enumerated(EnumType.STRING)
     @Column(name = "bank_code", nullable = false, updatable = false)
     private BankCode bankCode;
-
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 
     @Builder.Default
     @Column(name = "is_primary_account", nullable = false)

--- a/ssok-account-service/src/main/java/kr/ssok/accountservice/exception/AccountResponseStatus.java
+++ b/ssok-account-service/src/main/java/kr/ssok/accountservice/exception/AccountResponseStatus.java
@@ -12,8 +12,9 @@ public enum AccountResponseStatus implements ResponseStatus {
     /**
      * 1. 요청에 성공한 경우(2000~2999)
      */
-    ACCOUNT_CREATE_SUCCESS(true, 2001, "계좌 생성이 성공적으로 완료되었습니다."),
+    ACCOUNT_CREATE_SUCCESS(true, 2001, "계좌 등록을 완료했습니다."),
     ACCOUNT_GET_SUCCESS(true, 2000, "계좌 조회를 완료했습니다."),
+    ACCOUNT_DELETE_SUCCESS(true, 2000, "연동 계좌 삭제를 완료했습니다."),
 
     /**
      * 2. 클라이언트 에러(4000~4999)

--- a/ssok-account-service/src/main/java/kr/ssok/accountservice/service/AccountService.java
+++ b/ssok-account-service/src/main/java/kr/ssok/accountservice/service/AccountService.java
@@ -35,7 +35,6 @@ public interface AccountService {
      *
      * @param userId 사용자 ID
      * @return 조회된 연동 계좌 목록을 담은 List<AccountBalanceResponseDto>
-     * @throws kr.ssok.accountservice.exception.AccountException 계좌가 하나도 존재하지 않는 경우 발생
      */
     List<AccountBalanceResponseDto> findAllAccounts(Long userId);
 
@@ -45,7 +44,15 @@ public interface AccountService {
      * @param userId 사용자 ID
      * @param accountId 조회할 계좌 ID
      * @return 조회된 연동 계좌 정보를 담은 AccountBalanceResponseDto
-     * @throws kr.ssok.accountservice.exception.AccountException 해당 계좌가 존재하지 않는 경우 발생
      */
     AccountBalanceResponseDto findAccountById(Long userId, Long accountId);
+
+    /**
+     * 사용자 ID와 계좌 ID에 해당하는 연동 계좌를 삭제합니다.
+     *
+     * @param userId 사용자 ID
+     * @param accountId 삭제할 계좌 ID
+     * @return 삭제된 계좌의 기본 정보를 담은 {@link AccountResponseDto}
+     */
+    AccountResponseDto deleteLinkedAccount(Long userId, Long accountId);
 }

--- a/ssok-account-service/src/main/java/kr/ssok/accountservice/service/impl/AccountServiceImpl.java
+++ b/ssok-account-service/src/main/java/kr/ssok/accountservice/service/impl/AccountServiceImpl.java
@@ -69,10 +69,10 @@ public class AccountServiceImpl implements AccountService {
      */
     @Override
     public List<AccountBalanceResponseDto> findAllAccounts(Long userId) {
-        List<LinkedAccount> accounts = accountRepository.findByUserId(userId);
+        List<LinkedAccount> accounts = this.accountRepository.findByUserId(userId);
 
         if (accounts.isEmpty()) {
-            log.warn("[GET] No accounts found for userId: {}", userId);
+            log.warn("[GET] Account not found: userId={}", userId);
             throw new AccountException(AccountResponseStatus.ACCOUNT_NOT_FOUND);
         }
 
@@ -94,7 +94,7 @@ public class AccountServiceImpl implements AccountService {
      */
     @Override
     public AccountBalanceResponseDto findAccountById(Long userId, Long accountId) {
-        LinkedAccount account = accountRepository.findByAccountIdAndUserId(accountId, userId)
+        LinkedAccount account = this.accountRepository.findByAccountIdAndUserId(accountId, userId)
                 .orElseThrow(() -> {
                     log.warn("[GET] Account not found: accountId={}, userId={}", accountId, userId);
                     return new AccountException(AccountResponseStatus.ACCOUNT_NOT_FOUND);
@@ -102,6 +102,29 @@ public class AccountServiceImpl implements AccountService {
 
         // TODO. 추후, 으픈뱅킹 API 호출을 통해 balance 값에 실제 값을 대입
         return AccountBalanceResponseDto.from(100000000L, account);
+    }
+
+    /**
+     * 사용자 ID와 계좌 ID에 해당하는 연동 계좌를 삭제합니다.
+     *
+     * <p>해당하는 계좌가 존재하지 않는 경우 {@link AccountException}을 발생시킵니다.</p>
+     *
+     * @param userId 사용자 ID
+     * @param accountId 삭제할 계좌 ID
+     * @return 삭제된 계좌의 기본 정보를 담은 {@link AccountResponseDto}
+     * @throws AccountException 계좌를 찾을 수 없는 경우 발생
+     */
+    @Override
+    public AccountResponseDto deleteLinkedAccount(Long userId, Long accountId) {
+        LinkedAccount account = this.accountRepository.findByAccountIdAndUserId(accountId, userId)
+                .orElseThrow(() -> {
+                    log.warn("[DELETE] Account not found: accountId={}, userId={}", accountId, userId);
+                    return new AccountException(AccountResponseStatus.ACCOUNT_NOT_FOUND);
+                });
+
+        this.accountRepository.delete(account);
+
+        return AccountResponseDto.from(account);
     }
 
 

--- a/ssok-common/src/main/java/kr/ssok/common/entity/TimeStamp.java
+++ b/ssok-common/src/main/java/kr/ssok/common/entity/TimeStamp.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class TimeStamp {
     @CreatedDate
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate


### PR DESCRIPTION
## #️⃣ Issue Number

close #23 

## 📝 요약(Summary)

- 연동 계좌 삭제 REST API 개발, 테스트, 예외 처리
- 프론트에서 삭제 API 요청 시, DB로 부터 해당 유저의 계좌 정보를 삭제
- 이후, 삭제 결과를 프론트엔드에 다시 전달

**차후 고려 대상:**
- DB에 데이터 삭제 시, 인덱싱 관련 이슈있나 리서치 해볼 예정
- 예외 처리 코드 다시 확인 예정

## 📸스크린샷 (선택)
😮