### PR TITLE
feat: spring cloud config -> spring cloud kubernetes / config refactor (#58/SCRUM-146)

### DIFF
--- a/ssok-account-service/build.gradle
+++ b/ssok-account-service/build.gradle
@@ -32,11 +32,14 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // config-service
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    // Kubernetes Config
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
+    
+    // config-service (마이그레이션 중 호환성을 위해 유지, 나중에 제거 예정)
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/ssok-account-service/build.gradle
+++ b/ssok-account-service/build.gradle
@@ -37,9 +37,6 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
-    
-    // config-service (마이그레이션 중 호환성을 위해 유지, 나중에 제거 예정)
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/ssok-bluetooth-service/build.gradle
+++ b/ssok-bluetooth-service/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // config-service
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    // Kubernetes Config
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
     implementation "org.springframework.boot:spring-boot-starter-actuator"

--- a/ssok-gateway/build.gradle
+++ b/ssok-gateway/build.gradle
@@ -29,9 +29,6 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     
-    // Spring Cloud Config (마이그레이션 중 호환성을 위해 유지, 나중에 제거 예정)
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
-    
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     

--- a/ssok-gateway/build.gradle
+++ b/ssok-gateway/build.gradle
@@ -24,10 +24,13 @@ dependencies {
     // Spring Cloud Gateway
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 
-    // Spring Cloud Config
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    // Spring Cloud Kubernetes
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    
+    // Spring Cloud Config (마이그레이션 중 호환성을 위해 유지, 나중에 제거 예정)
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
     
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/ssok-notification-service/build.gradle
+++ b/ssok-notification-service/build.gradle
@@ -46,8 +46,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // config-service
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    // Kubernetes Config
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
     implementation "org.springframework.boot:spring-boot-starter-actuator"

--- a/ssok-transfer-service/build.gradle
+++ b/ssok-transfer-service/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // config-service
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    // Kubernetes Config
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
     implementation "org.springframework.boot:spring-boot-starter-actuator"

--- a/ssok-user-service/build.gradle
+++ b/ssok-user-service/build.gradle
@@ -53,9 +53,6 @@ dependencies {
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
-    
-    // config-service (마이그레이션 중 호환성을 위해 유지, 나중에 제거 예정)
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
 
     // H2(테스트용)
     runtimeOnly 'com.h2database:h2'

--- a/ssok-user-service/build.gradle
+++ b/ssok-user-service/build.gradle
@@ -48,11 +48,14 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // config-service
-    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    // Kubernetes Config
+    implementation 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-config'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
+    
+    // config-service (마이그레이션 중 호환성을 위해 유지, 나중에 제거 예정)
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
 
     // H2(테스트용)
     runtimeOnly 'com.h2database:h2'


### PR DESCRIPTION
## #️⃣ Issue Number

close #58 

## 📝 요약(Summary)

기존의 spring cloud config + rabbitMQ 방식으로는 k8s 환경에서 pods 리소스를 더 차지하는 상황
-> k8s의 configMap + Secret 방식을 사용하려고 함 (리소스 X)
-> 기존의 spring cloud config, rabbitMQ 방식의 refresh 기능을 사용할 수 없게됨
-> spring cloud kubernetes 의존성을 각 서비스에 추가하고 configMap, secret을 조합하여 사용 (리소스X, refresh 가능)

라는 이유로 spring cloud kubernetes로 migration 작업했습니다.

## 📸스크린샷 (선택)
