### PR TITLE
fix: redisconfig 빈 이름 충돌 해결

### DIFF
--- a/ssok-user-service/src/main/java/kr/ssok/userservice/config/RedisConfig.java
+++ b/ssok-user-service/src/main/java/kr/ssok/userservice/config/RedisConfig.java
@@ -11,15 +11,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
     @Bean
-    public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-        return template;
-    }
-
-    @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);


### PR DESCRIPTION
## #️⃣ Issue Number

#223 

## 📝 요약(Summary)

stringRedisTemplate 빈 제거: Spring Boot가 자동으로 제공하는 StringRedisTemplate을 사용
redisTemplate 빈만 유지: UserServiceImpl에서 필요한 RedisTemplate<String, Object> 제공

## 📸스크린샷 (선택)
